### PR TITLE
Remove 'wpkit-admin' from webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,7 +12,6 @@ const TerserPlugin = require( 'terser-webpack-plugin' );
 const entry = {
 	'wpkit-frontend': path.resolve( __dirname, './assets/scripts/frontend/wpkit-frontend.js' ),
 	'wpkit-editor': path.resolve( __dirname, './assets/scripts/editor/wpkit-editor.js' ),
-	'wpkit-admin': path.resolve( __dirname, './assets/scripts/admin/wpkit-admin.js' ),
 }
 
 const copyPluginConfig = new CopyPlugin( {


### PR DESCRIPTION
In the webpack configuration file, the 'wpkit-admin' entry has been deleted. This change reflects that we're no longer bundling scripts specific to the 'wpkit-admin' area in our project.