### PR TITLE
Update package name and slug in theme JSON file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-	"name": "wp-kit-elementor-theme",
-	"slug": "wp-kit-elementor-theme",
+	"name": "wp-kit-elementor",
+	"slug": "wp-kit-elementor",
 	"homepage": "https://wpkit.pro",
 	"description": "A sample WordPress theme for Elementor page builder.",
 	"version": "1.0.5",


### PR DESCRIPTION
The "name" and "slug" properties in the package.json file for the wp-kit-elementor theme have been modified. The "-theme" suffix has been removed in both properties to make them more consistent with the project's naming convention.