### PR TITLE
Update dotenv.config path in Elementor script

### DIFF
--- a/.github/scripts/update-version-in-files.js
+++ b/.github/scripts/update-version-in-files.js
@@ -2,7 +2,7 @@
 
 const dotenv = require( 'dotenv' );
 const path = require( 'path' );
-dotenv.config( { path: path.resolve( __dirname, '.env' ) } );
+dotenv.config( { path: path.resolve( '../../.env' ) } );
 const replaceInFile = require( 'replace-in-file' );
 
 const { VERSION } = process.env;


### PR DESCRIPTION
This commit adjusts the path used for 'dotenv.config' in the update-version-in-files.js script. The script is part of the wp-kit-elementor theme, and changing the path ensures the script can access the '.env' configuration file correctly. This change is critical for the proper functioning of the script for version updating tasks.